### PR TITLE
docs: clarify non-interactive pool exec setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ By default, pool asks for approval before each tool call. Switch to Accept edits
 | ------------- | -------------- | ------------------------------------------------------------------ |
 | Always ask    | `default`      | Prompts for approval on first use of each tool type                |
 | Accept edits  | `accept-edits` | Auto-approves workspace file reads and writes                      |
-| Allow all     | `allow-all`    | Approves tool calls automatically                                  |
+| Allow all     | `always-allow` | Approves tool calls automatically                                  |
 | Plan          | `plan`         | Plans changes without modifying your codebase                      |
 
 Press `Shift+Tab` to cycle through modes, or use `/mode <id>` to switch directly.
@@ -105,7 +105,7 @@ To pass flags to the ACP server, add them to the args array, for example `["acp"
 ### ACP features
 
 - Session persistence: `session/list` and `session/load`
-- Session config options: mode and model. These can be persisted in `settings.yaml`
+- Session config options: mode, model, and thought level when supported. These can be persisted in `settings.yaml`
   and are sent on startup using `session/set_config_option`
 - Slash commands advertised to the client
 
@@ -168,7 +168,7 @@ pool exec -f prompt.txt -o json
 
 [OpenRouter](https://openrouter.ai) is supported natively in `pool`.
 
-Run `pool login` and select `Log in with OpenRouter`.
+Run `pool login` and select `Use your OpenRouter account`.
 
 ## Ollama
 

--- a/README.md
+++ b/README.md
@@ -164,15 +164,15 @@ pool exec -p "scan cmd/cli code for vulnerabilities" -o json --unsafe-auto-allow
 pool exec -f prompt.txt -o json
 ```
 
-### Connect to Poolside Platform from CI
-
-In CI or another headless environment without credentials saved by `pool login`, set your Poolside Platform API key and endpoint before you run `pool exec`:
+Running `pool exec` non-interactively does not select standalone mode automatically. In CI or another headless environment without credentials saved by `pool login`, set the API key and base URL for your provider:
 
 ```bash
 POOLSIDE_API_KEY="<api-key>" \
-  POOLSIDE_STANDALONE_BASE_URL="https://inference.poolside.ai" \
+  POOLSIDE_STANDALONE_BASE_URL="<provider-base-url>" \
   pool exec -p "<prompt>" -o json --unsafe-auto-allow
 ```
+
+For Poolside Platform, use `https://inference.poolside.ai` as the base URL.
 
 To choose a model instead of using the default, also set `POOLSIDE_STANDALONE_MODEL` to its model ID.
 
@@ -239,7 +239,7 @@ Run `pool config` to print the log, trajectory, and configuration directories, a
 
 By default, Poolside stores configuration files in `~/.config/poolside`. This includes `settings.yaml` (CLI settings), `credentials.json` (API token).
 
-For automation environments without credentials saved by `pool login`, set `POOLSIDE_API_KEY` and the provider endpoint. See [Connect to Poolside Platform from CI](#connect-to-poolside-platform-from-ci).
+For automation environments without credentials saved by `pool login`, set `POOLSIDE_API_KEY` and the provider endpoint. See [Run non-interactively (`pool exec`)](#run-non-interactively-pool-exec).
 
 ### settings.yaml reference
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,18 @@ pool exec -p "scan cmd/cli code for vulnerabilities" -o json --unsafe-auto-allow
 pool exec -f prompt.txt -o json
 ```
 
+### Connect to Poolside Platform from CI
+
+In CI or another headless environment without credentials saved by `pool login`, set your Poolside Platform API key and endpoint before you run `pool exec`:
+
+```bash
+POOLSIDE_API_KEY="<api-key>" \
+  POOLSIDE_STANDALONE_BASE_URL="https://inference.poolside.ai" \
+  pool exec -p "<prompt>" -o json --unsafe-auto-allow
+```
+
+To choose a model instead of using the default, also set `POOLSIDE_STANDALONE_MODEL` to its model ID.
+
 ## OpenRouter
 
 [OpenRouter](https://openrouter.ai) is supported natively in `pool`.
@@ -227,7 +239,7 @@ Run `pool config` to print the log, trajectory, and configuration directories, a
 
 By default, Poolside stores configuration files in `~/.config/poolside`. This includes `settings.yaml` (CLI settings), `credentials.json` (API token).
 
-For automation environments, set `POOLSIDE_API_KEY` instead of using stored credentials. `pool` checks it before reading from configuration files.
+For automation environments without credentials saved by `pool login`, set `POOLSIDE_API_KEY` and the provider endpoint. See [Connect to Poolside Platform from CI](#connect-to-poolside-platform-from-ci).
 
 ### settings.yaml reference
 


### PR DESCRIPTION
## Summary

- Update README mode, ACP, and OpenRouter terminology to match current CLI behavior.
- Document non-interactive `pool exec` setup for CI/headless environments, including API key, provider base URL, and optional model selection.
- Clarify automation credential requirements and link them to the CI setup guidance.

## Testing

- Not run (documentation-only changes).