### PR TITLE
Docs: Clarify CLI modes and context length

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ pool is [Poolside](https://poolside.ai)’s coding agent. It can run in several 
 
 - [Install](#install)
 - [Quick start](#quick-start)
-- [Modes](#modes)
+- [Approval modes](#approval-modes)
+- [Agent modes](#agent-modes)
 - [Spec support](#spec-support)
 - [Run as an ACP server (`pool acp`)](#run-as-an-acp-server-pool-acp)
 - [Run as an ACP client (`pool --agent-server`)](#run-as-an-acp-client-pool---agent-server)
@@ -61,18 +62,23 @@ Run `pool -h` to see all available options.
 
 Enter `?` or `/help` during a session to see all available commands and shortcuts.
 
-## Modes
+## Approval modes
 
 By default, pool asks for approval before each tool call. Switch to Accept edits or Allow all when you want it to take actions without prompting.
 
-| Mode          | ID             | What it does                                                       |
-| ------------- | -------------- | ------------------------------------------------------------------ |
-| Always ask    | `default`      | Prompts for approval on first use of each tool type                |
-| Accept edits  | `accept-edits` | Auto-approves workspace file reads and writes                      |
-| Allow all     | `always-allow` | Approves tool calls automatically                                  |
-| Plan          | `plan`         | Plans changes without modifying your codebase                      |
+| Approval mode | ID             | What it does                                  |
+| ------------- | -------------- | --------------------------------------------- |
+| Always ask    | `default`      | Prompts for approval on first use of each tool type |
+| Accept edits  | `accept-edits` | Auto-approves workspace file reads and writes |
+| Allow all     | `always-allow` | Approves tool calls automatically             |
 
-Press `Shift+Tab` to cycle through modes, or use `/mode <id>` to switch directly.
+Press `Shift+Tab` to cycle through approval modes, or use `/mode <approval-mode>` to switch directly.
+
+## Agent modes
+
+Build and Plan control how pool works without changing approval behavior. In Plan mode, pool can inspect your codebase and prepare a plan without modifying source files.
+
+After starting pool, use `/plan` or `/agent-mode plan` to enter Plan mode. Use `/agent-mode build` to return to Build mode. There is no Plan-mode startup flag.
 
 ## Spec support
 
@@ -205,7 +211,7 @@ POOLSIDE_STANDALONE_BASE_URL="http://127.0.0.1:8080" POOLSIDE_API_KEY="EMPTY" po
 Optional environment variables you can pass:
 
 - `POOLSIDE_STANDALONE_MODEL` to set the model
-- `POOLSIDE_STANDALONE_CONTEXT_LENGTH` to set the context length
+- `POOLSIDE_STANDALONE_CONTEXT_LENGTH` to override, in tokens, the context length `pool` uses to calculate automatic compaction thresholds
 
 ```bash
 POOLSIDE_STANDALONE_BASE_URL="http://127.0.0.1:8080" \
@@ -214,6 +220,8 @@ POOLSIDE_STANDALONE_MODEL="ggml-org/gemma-3-1b-it-GGUF" \
 POOLSIDE_STANDALONE_CONTEXT_LENGTH=200000 \
 pool
 ```
+
+Use a positive `POOLSIDE_STANDALONE_CONTEXT_LENGTH` value no greater than the model server's context window. The override does not change that window and applies only when the selected model appears in the provider's `/v1/models` response.
 
 ## MCP servers
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ Enter `?` or `/help` during a session to see all available commands and shortcut
 
 ## Approval modes
 
-By default, pool asks for approval before each tool call. Switch to Accept edits or Allow all when you want it to take actions without prompting.
+By default, pool asks for approval before tool actions that are not already allowed. Switch to Accept edits or Allow all when you want it to take actions without prompting.
 
 | Approval mode | ID             | What it does                                  |
 | ------------- | -------------- | --------------------------------------------- |
-| Always ask    | `default`      | Prompts for approval on first use of each tool type |
+| Always ask    | `default`      | Prompts for tool actions that are not already allowed |
 | Accept edits  | `accept-edits` | Auto-approves workspace file reads and writes |
 | Allow all     | `always-allow` | Approves tool calls automatically             |
 
@@ -111,7 +111,7 @@ To pass flags to the ACP server, add them to the args array, for example `["acp"
 ### ACP features
 
 - Session persistence: `session/list` and `session/load`
-- Session config options: mode, model, and thought level when supported. These can be persisted in `settings.yaml`
+- Session config options: approval mode, agent mode, model, and thought level when supported. These can be persisted in `settings.yaml`
   and are sent on startup using `session/set_config_option`
 - Slash commands advertised to the client
 


### PR DESCRIPTION
## Summary

- Split approval modes and Build/Plan agent modes into separate README sections.
- Document how to enter and leave Plan mode, including the absence of a Plan-mode startup flag.
- Clarify that `POOLSIDE_STANDALONE_CONTEXT_LENGTH` controls automatic compaction thresholds and does not change the model server context window.

## Verification

- `git diff --check`
- Reviewed the documented commands and environment-variable behavior against the v1.0.15 implementation.