### PR TITLE
docs: mention agent hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ web_search:
   summarize_results: true   # summarize fetched pages with the session model
 ```
 
+**Hooks**: run your own shell commands at agent lifecycle events (`PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `Stop`, `PreCompact`, `SessionStart`) to block or rewrite tool calls, inject context, or keep the agent working. Configured under `hooks:` in `settings.yaml` — see the [hooks documentation](https://docs.poolside.ai/cli/hooks).
+
 **Disabling a tool**:
 
 ```yaml


### PR DESCRIPTION
pool now supports lifecycle hooks configured in `settings.yaml`, but nothing in this repo mentioned them.

This adds a short Hooks entry to the README's settings reference, pointing at the full docs page, so people discovering pool here can find the feature. The CHANGELOG is untouched: it has no Unreleased section, so the hooks line belongs in the next release's section when it is cut.